### PR TITLE
Added 'AllowSameAsOriginal' option to postFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The `options` object is required. Options include:
 - **options.format** - File format ([list here](https://github.com/onesky/api-documentation-platform/blob/master/reference/format.md))
 - **options.content** String with the content of the file
 - **options.keepStrings** Boolean saying if already uploaded strings not present on this file should be deprecated or keept
+- **options.AllowSameAsOriginal** Keep the translations that are the same as source text (Optional. Defaults to `false`)
 - **options.secret** - `secret` and `apiKey` are used for authentication
 - **options.apiKey**
 

--- a/lib/postFile.js
+++ b/lib/postFile.js
@@ -51,7 +51,8 @@ function _getUploadOptions (options) {
       file_format: options.format,
       is_keeping_all_strings: options.keepStrings.toString(),
       locale: options.language,
-      timestamp: options.hash.timestamp.toString()
+      timestamp: options.hash.timestamp.toString(),
+      is_allow_translation_same_as_original: (options.AllowSameAsOriginal || false).toString()
     }
   };
 }


### PR DESCRIPTION
I found this param in the API documentation but not in this package:
https://github.com/onesky/api-documentation-platform/blob/master/resources/file.md#upload---upload-a-file
