### PR TITLE
Fix module name in require() statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ npm i @brainly/onesky-utils
 ### getFile
 
 ```js
-var onesky = require('onesky-utils');
+var onesky = require('@brainly/onesky-utils');
 
 var options = {
   language: 'en_EN',


### PR DESCRIPTION
Need to add `@brainly/` prefix to module name to make it work, now that the package name is `@brainly/onesky-utils` and not just `onesky-utils`