### PR TITLE
Remove trailing slash in apiAddress global variable

### DIFF
--- a/lib/globals.js
+++ b/lib/globals.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var _globals = {
-  apiAddress: 'https://platform.api.onesky.io/'
+  apiAddress: 'https://platform.api.onesky.io'
 };
 
 module.exports = _globals;

--- a/test/postFile.js
+++ b/test/postFile.js
@@ -51,7 +51,7 @@ describe('POST translations with wrong credentials', function () {
     requestPromise = new Promise(function (resolve, reject) {
       reject({
         response: {
-          body: '{ message: \'Unable to upload document\', code: 400 }'
+          body: '{ "message": "Unable to upload document", "code": 400 }'
         }
       });
     });

--- a/test/postScreenshot.js
+++ b/test/postScreenshot.js
@@ -1,82 +1,82 @@
 /* eslint-env mocha */
-'use strict';
+"use strict";
 
-function rootRequire (name) {
-  return require(__dirname + '/../' + name);
+function rootRequire(name) {
+  return require(__dirname + "/../" + name);
 }
 
-var mockery = require('mockery');
-var chai = require('chai');
+var mockery = require("mockery");
+var chai = require("chai");
 var expect = chai.expect;
-var sinon = require('sinon');
-var sinonChai = require('sinon-chai');
+var sinon = require("sinon");
+var sinonChai = require("sinon-chai");
 var requestPromise;
 var oneskyUtils;
 var defaultOptions;
 
 chai.use(sinonChai);
 
-describe('POST screenshots', function () {
+describe("POST screenshots", function () {
   afterEach(function () {
-    mockery.deregisterSubstitute('request-promise');
+    mockery.deregisterSubstitute("request-promise");
     mockery.disable();
   });
 
   beforeEach(function () {
     defaultOptions = {
-      projectId: 'projectId',
-      secret: 'secret',
-      apiKey: 'apiKey',
-      name: 'name',
-      image: 'image',
+      projectId: "projectId",
+      secret: "secret",
+      apiKey: "apiKey",
+      name: "name",
+      image: "image",
       tags: [
         {
-          key: 'key',
+          key: "key",
           x: 1,
           y: 2,
           width: 3,
           height: 4,
-          file: 'file'
-        }
-      ]
+          file: "file",
+        },
+      ],
     };
-    mockery.registerMock('request-promise', function (request) {
+    mockery.registerMock("request-promise", function (request) {
       // Assert well formed request
-      expect(request.method).to.equal('POST');
+      expect(request.method).to.equal("POST");
       expect(request.form.secret).to.be.undefined;
-      expect(request.form.api_key).to.equal('apiKey');
+      expect(request.form.api_key).to.equal("apiKey");
       expect(request.form.dev_hash).to.not.be.undefined;
       expect(request.form.timestamp).to.not.be.undefined;
 
       var screenshot = request.form.screenshots[0];
       expect(request.form.screenshots).to.not.be.undefined;
 
-      expect(screenshot.name).to.equal('name');
-      expect(screenshot.image).to.equal('image');
-      expect(screenshot.tags[0].key).to.equal('key');
+      expect(screenshot.name).to.equal("name");
+      expect(screenshot.image).to.equal("image");
+      expect(screenshot.tags[0].key).to.equal("key");
       expect(screenshot.tags[0].x).to.equal(1);
       expect(screenshot.tags[0].y).to.equal(2);
       expect(screenshot.tags[0].width).to.equal(3);
       expect(screenshot.tags[0].height).to.equal(4);
-      expect(screenshot.tags[0].file).to.equal('file');
+      expect(screenshot.tags[0].file).to.equal("file");
 
       return requestPromise;
     });
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false,
-      useCleanCache: true
+      useCleanCache: true,
     });
 
-    oneskyUtils = rootRequire('index.js');
+    oneskyUtils = rootRequire("index.js");
   });
 
-  it('Return error request fails with 400', function () {
+  it("Return error request fails with 400", function () {
     requestPromise = new Promise(function (resolve, reject) {
       reject({
         response: {
-          body: "{ message: 'Unable to upload document', code: 400 }"
-        }
+          body: '{ "message": "Unable to upload document", "code": 400 }',
+        },
       });
     });
 
@@ -87,19 +87,19 @@ describe('POST screenshots', function () {
       })
       .catch(function (error) {
         expect(error.code).to.equal(400);
-        expect(error.message).to.equal('Unable to upload document');
+        expect(error.message).to.equal("Unable to upload document");
       });
   });
 
-  it('Return success on valid content', function (done) {
+  it("Return success on valid content", function (done) {
     var successCallback = sinon.spy();
     var errorCallback = sinon.spy();
 
     requestPromise = new Promise(function (resolve, reject) {
       resolve({
         response: {
-          body: '{"meta":{"status":201},"data":{}}'
-        }
+          body: '{"meta":{"status":201},"data":{}}',
+        },
       });
     });
 


### PR DESCRIPTION
Each API call already adds leading slash to the address, like so:

```javascript
function _getUploadOptions (options) {
  return {
    method: 'POST',
    url: apiAddress + '/1/projects/' + options.projectId ...
```

This results in double slash `https://platform.api.onesky.io//1/projects/...`.

Until recently it wasn't a problem, but OneSky started redirecting these calls to `http://www.oneskyapp.com//1/projects/...` so whole thing fails with a cryptic error.